### PR TITLE
Add the ability to specify extra modules to process

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
         "node": ">=16.0"
     },
     "dependencies": {
-        "ilib-common": "^1.0.3",
-        "ilib-locale": "^1.1.1",
+        "ilib-common": "^1.1.0",
+        "ilib-locale": "^1.2.0",
         "json5": "^2.2.1",
         "options-parser": "^0.4.0"
     }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -55,6 +55,11 @@ const optionConfig = {
         "default": "en-AU,en-CA,en-GB,en-IN,en-NG,en-PH,en-PK,en-US,en-ZA,de-DE,fr-CA,fr-FR,es-AR,es-ES,es-MX,id-ID,it-IT,ja-JP,ko-KR,pt-BR,ru-RU,tr-TR,vi-VN,zxx-XX,zh-Hans-CN,zh-Hant-HK,zh-Hant-TW,zh-Hans-SG",
         help: "Locales you want your webapp to support. Value is a comma-separated list of BCP-47 style locale tags. Default: the top 20 locales on the internet by traffic."
     },
+    module: {
+        short: "m",
+        multi: true,
+        help: "Explicitly add the locale data for a module that is not otherwise mentioned in the source code. Parameter gives a relative path to the module, including the leading './'. Typically, this would be in ./node_modules, but it could be anywhere on disk. This option may be specified multiple times, once for each module to add." 
+    },
     quiet: {
         short: "q",
         flag: true,
@@ -125,6 +130,13 @@ files.forEach((file) => {
     if (!options.opt.quiet) console.log(`  ${file} ...`);
     scan(file, ilibModules);
 });
+
+if (options.opt.module) {
+    options.opt.module.forEach(module => {
+        if (!options.opt.quiet) console.log(`\nAdding module ${module} to the list of modules to search`);
+        ilibModules.add((module[0] === '.') ? path.join(process.cwd(), module) : module);
+    });
+}
 
 let localeData = {};
 

--- a/src/scanmodule.mjs
+++ b/src/scanmodule.mjs
@@ -90,14 +90,16 @@ const require = createRequire(import.meta.url);
  * data, and return it in the format documented above
  */
 function scanModule(moduleName, options) {
-    let resolved;
-    try {
-        resolved = require.resolve(moduleName);
-        const i = resolved.indexOf(moduleName);
-        resolved = resolved.substring(0, i + moduleName.length);
-    } catch (e) {
-        console.log(`    Error: could not find module ${moduleName}`);
-        return Promise.resolve(false);
+    let resolved = moduleName;
+    if ( moduleName[0] !== '.' && moduleName[0] !== '/') {
+        try {
+            resolved = require.resolve(moduleName);
+            const i = resolved.indexOf(moduleName);
+            resolved = resolved.substring(0, i + moduleName.length);
+        } catch (e) {
+            console.log(`    Error: could not find module ${moduleName}`);
+            return Promise.resolve(false);
+        }
     }
 
     if (!existsSync(path.join(resolved, "assemble.mjs")) || !existsSync(path.join(resolved, "locale"))) {


### PR DESCRIPTION
- introduce the --module or -m command-line options to add a module to the list of ones to process. This is needed for ilib libraries to add their own locale data to the assembled files before they are published on npm
- added a --localefile option to be able to read the list of locales to process from a json file
- when a locale is a region only, get the data from und-REGION rather than just the REGION directory
- default export for the js files is now a function that returns the `getLocaleData()` function which returns the actual data