### PR TITLE
Use ESM versions of the other ilib packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.1.2
+
+- work with the hybrid commonjs/ESM modules
+
 ### v1.1.1
 
 - Updated dependencies to avoid the polyfill bloat

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
         "node": ">=16.0"
     },
     "dependencies": {
-        "ilib-common": "file:../ilib-common/ilib-common-1.1.2.tgz",
-        "ilib-locale": "file:../ilib-locale/ilib-locale-1.2.2.tgz",
+        "ilib-common": "^1.1.2",
+        "ilib-locale": "^1.2.2",
         "json5": "^2.2.1",
         "options-parser": "^0.4.0"
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "name": "ilib-assemble",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "./src/index.mjs",
+	"type": "module",
     "bin": {
         "ilib-assemble": "./src/index.mjs",
         "ilib-assemble.bat": "./ilib-assemble.bat"
@@ -63,8 +64,8 @@
         "node": ">=16.0"
     },
     "dependencies": {
-        "ilib-common": "^1.1.1",
-        "ilib-locale": "^1.2.1",
+        "ilib-common": "file:../ilib-common/ilib-common-1.1.2.tgz",
+        "ilib-locale": "file:../ilib-locale/ilib-locale-1.2.2.tgz",
         "json5": "^2.2.1",
         "options-parser": "^0.4.0"
     }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -21,7 +21,7 @@
  */
 
 import OptionsParser from 'options-parser';
-import LocalePkg from 'ilib-locale';
+import Locale from 'ilib-locale';
 import { JSUtils } from 'ilib-common';
 import fs from 'fs';
 import path from 'path';
@@ -31,8 +31,6 @@ import json5 from 'json5';
 import walk from './walk.mjs';
 import scan from './scan.mjs';
 import scanModule from './scanmodule.mjs';
-
-const Locale = LocalePkg.default;
 
 const optionConfig = {
     help: {


### PR DESCRIPTION
This depends on the ESM module via the hybrid packages. This tool does not run properly under node 10 or earlier. v12 or later only.