### PR TITLE
Remove the mkdirp package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.2.2
+- Removed the `mkdirp` package dependency.
+
 ### v1.2.0
 
 - added --resources option to include translated resource files into the

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for more details.
 
 ## License
 
-Copyright © 2022, JEDLSoft
+Copyright © 2022, 2024 JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -194,6 +194,9 @@ limitations under the License.
 
 ### v1.2.2
 - Removed the `mkdirp` package dependency.
+
+### v1.2.1
+- converted all unit tests from nodeunit to jest
 
 ### v1.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-assemble",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "main": "./src/index.js",
     "type": "module",
     "bin": {
@@ -72,7 +72,6 @@
         "ilib-common": "^1.1.3",
         "ilib-locale": "^1.2.2",
         "json5": "^2.2.3",
-        "mkdirp": "^3.0.1",
         "options-parser": "^0.4.0"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ import Locale from 'ilib-locale';
 import { JSUtils, Utils } from 'ilib-common';
 import fs from 'fs';
 import path from 'path';
-import mkdirp from 'mkdirp';
 import json5 from 'json5';
 
 import walk from './walk.js';
@@ -99,7 +98,7 @@ try {
 
 if (!stat) {
     // file not found, so let's make it
-    mkdirp(outputPath);
+    fs.mkdirSync(outputPath);
     if (!options.opt.quiet) console.log(`Created output path: ${outputPath}`);
 } else if (stat.errno) {
     console.log(`Could not access ${outputPath}`);

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ try {
 
 if (!stat) {
     // file not found, so let's make it
-    fs.mkdirSync(outputPath);
+    fs.mkdirSync(outputPath, { recursive: true });
     if (!options.opt.quiet) console.log(`Created output path: ${outputPath}`);
 } else if (stat.errno) {
     console.log(`Could not access ${outputPath}`);


### PR DESCRIPTION
When executing `node src/index.js` an error is displayed below.
and it looks like mkdirp only creates directories. So I think it is ok to replace it with fs.mkdirSync.

```
goun@goun-linux:~/Source/ilib-assemble$ node src/index.js 
file:///home/goun/Source/ilib-assemble/src/index.js:28
import mkdirp from 'mkdirp';
       ^^^^^^
SyntaxError: The requested module 'mkdirp' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
```