### PR TITLE
Add customLocalePath to provide a way of overriding user-defined locale data

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The ilib-assemble tool takes the following options:
     the default (`./src/ilib-all-inc.js`)file will be used.
 * --outjsFileName or n. Specify the resulting assembled output file name.
     The default is `ilib-all.js`
+* -- customLocalePath or p. Specify the location where the custom locale data path. If you want to override the value of existing locale data.
 
 The output-dir is required and specifies the directory where the output is
 written. If it does not exist, it will be created first.
@@ -218,6 +219,7 @@ limitations under the License.
 ## Release Notes
 
 ### v1.3.0
+- Removed the `mkdirp` package dependency.
 - Add the ability to assemble the legacy version of iLib.  
   When the legacyilib flag is set, it assembles files in the legacy style, which refers to the files from iLib. The generated output includes separate files for JS code and locale data: one JS file containing the JS code and iLib's root locale data, and additional JSON files for 
   locale-specific data. Currently, it generates files in the `[language].js` format.   
@@ -226,9 +228,9 @@ e.g
 ```
  ilib-assemble output-dir --legacyilib --ilibPath ~/Source/develop/ --ilibincPath src/ilib-all-inc.js -l "af-ZA,am-ET,ko-KR"
 ```
+- Add the option `customLocalePath` to provide a possibility to overwrite the locale data. Basically, the locale data is based on the CLDR.  
+ If you want to have it to return a different value, Prepare the JSON locale data to override the same locale hierarchy and use the option when running the tool.
 
-### v1.2.2
-- Removed the `mkdirp` package dependency.
 
 ### v1.2.1
 - converted all unit tests from nodeunit to jest

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ The ilib-assemble tool takes the following options:
     the default (`./src/ilib-all-inc.js`)file will be used.
 * --outjsFileName or n. Specify the resulting assembled output file name.
     The default is `ilib-all.js`
-* -- customLocalePath or p. Specify the location where the custom locale data path. If you want to override the value of existing locale data.
+* --customLocalePath or p. Specify the path to customized locale data that
+    overrides existing open-source locale data.
 
 The output-dir is required and specifies the directory where the output is
 written. If it does not exist, it will be created first.
@@ -228,8 +229,8 @@ e.g
 ```
  ilib-assemble output-dir --legacyilib --ilibPath ~/Source/develop/ --ilibincPath src/ilib-all-inc.js -l "af-ZA,am-ET,ko-KR"
 ```
-- Add the option `customLocalePath` to provide a possibility to overwrite the locale data. Basically, the locale data is based on the CLDR.  
- If you want to have it to return a different value, Prepare the JSON locale data to override the same locale hierarchy and use the option when running the tool.
+- Add the option `customLocalePath` to override the locale data with custom data.  
+  The open-source locale data is based only on the CLDR. If your company wants override certain settings, it can create custom JSON locale data in the same format and the same locale hierarchy as the ilib files, and any data in the custom files will override the parallel data from CLDR.
 
 
 ### v1.2.1

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,11 @@ const optionConfig = {
         short: "n",
         "default": "ilib-all.js",
         help: "Specify the resulting assembled output file name for legacy ilib assembly."
+    },
+    customLocalePath: {
+        short: "p",
+        "default" : undefined,
+        help: "Specify the location where the custom locale data path. If you want to override the value of existing locale data."
     }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ const optionConfig = {
     legacyilib: {
         short: "o",
         flag: true,
-        help: "Assemble data for the legacy version of ilib"
+        help: "Assemble data for the legacy version of ilib."
     },
     ilibPath: {
         short: "i",
@@ -98,7 +98,7 @@ const optionConfig = {
     customLocalePath: {
         short: "p",
         "default" : undefined,
-        help: "Specify the location where the custom locale data path. If you want to override the value of existing locale data."
+        help: "Specify the path to customized locale data that overrides existing open-source locale data."
     }
 };
 

--- a/src/legacyilibassemble.js
+++ b/src/legacyilibassemble.js
@@ -302,7 +302,7 @@ function assembleLocale() {
     for (let loc in result) {
         let contents = "";
         for(let keys in result[loc]){
-            contents += keys + " = " + JSON.stringify(result[loc][keys]) + "\n";
+            contents += keys + " = " + JSON.stringify(result[loc][keys]) + ";\n";
         }
         console.log("writing " + outDir + "/"+ loc + ".js file.");
         let resultFilePath = path.join(outDir, loc + ".js");

--- a/src/legacyilibassemble.js
+++ b/src/legacyilibassemble.js
@@ -186,124 +186,100 @@ function assemblejs() {
     }
 }
 
-function assembleCustomLocale(data) {
-    let allData = data;
-
+function assembleData(dataPath, allData){
+    let outFile  = allData;
+    let jsonPath;
+    let key = '';
+    let orgData;
+    let parseData;
+    let readData;
+    let mergeData;
     locales.forEach(function(loc){
         let lo = new Locale(loc);
-        let lang = lo.language;
-        let script = lo.script;
-        let region = lo.region;
-        let jsonPath;
-        let readData;
+        let lang = lo.getLanguage();
+        let script = lo.getScript();
+        let region = lo.getRegion();
 
-        dependentData.forEach(function(jsonName) {
-            let key = '';
-            let orgData;
-            let customData;
-            if (lang) {
-                jsonPath = path.join(customPath, lang, jsonName + ".json");
-                readData = readFile(jsonPath);
-
-                if (readData) {
-                    key = "ilib.data." + jsonName + "_" + lang;
-                    orgData = ((allData[lang][key]) != undefined) ? JSON.parse(allData[lang][key]) : {};
-                    customData = JSON.parse(readData);
-                    orgData = JSUtils.merge(orgData, customData, true);
-                    allData[lang][key] = JSON.stringify(orgData);
-                }
-                if (script) {
-                    jsonPath = path.join(customPath, lang, script, jsonName + ".json");
-                    readData = readFile(jsonPath);
-
-                    if (readData) {
-                        key = "ilib.data." + jsonName + "_" + lang + "_" + script;
-                        orgData = ((allData[lang][key]) != undefined) ? JSON.parse(allData[lang][key]) : {};
-                        customData = JSON.parse(readData);
-                        orgData = JSUtils.merge(orgData, customData, true);
-                        allData[lang][key] = JSON.stringify(orgData);
-                    }
-
-                    if (region) {
-                        jsonPath = path.join(customPath, lang, script, region, jsonName + ".json");
-                        readData = readFile(jsonPath);
-                        if (readData) {
-                            key = "ilib.data." + jsonName + "_" + lang + "_" + script + "_" + region;
-                            orgData = ((allData[lang][key]) != undefined) ? JSON.parse(allData[lang][key]) : {};
-                            customData = JSON.parse(readData);
-                            orgData = JSUtils.merge(orgData, customData, true);
-                            allData[lang][key] = JSON.stringify(orgData);
-                        }
-
-                    }
-                } else if (region) {
-                    jsonPath = path.join(customPath, lang, region, jsonName + ".json");
-                    readData = readFile(jsonPath);
-
-                    if (readData) {
-                        key = "ilib.data." + jsonName + "_" + lang + "_" + region;
-                        orgData = ((allData[lang][key]) != undefined) ? JSON.parse(allData[lang][key]) : {};
-                        customData = JSON.parse(readData);
-                        orgData = JSUtils.merge(orgData, customData, true);
-                        allData[lang][key] = JSON.stringify(orgData);
-                    }
-                }
-            } else {
-                console.log("The locale " + lo.getSpec() +  " is missing language code.");
-            }
-        });
-
-    });
-    return allData;
-}
-
-let outFile = {};
-function assembleLocale() {
-    let iliblocalePath = path.join(ilibPath, "js/data/locale");
-    locales.forEach(function(loc){
-        let lo = new Locale(loc);
-        let lang = lo.language;
-        let script = lo.script;
-        let region = lo.region;
-
-        let jsonPath;
-        let readData;
         dependentData.forEach(function(jsonName) {
             if (outFile[lang] == undefined) {
                 outFile[lang] = {};
             }
 
             if (lang) {
-                jsonPath = path.join(iliblocalePath, lang, jsonName + ".json");
+                jsonPath = path.join(dataPath, lang, jsonName + ".json");
                 readData = readFile(jsonPath);
-                if (readData) outFile[lang]["ilib.data." + jsonName + "_" + lang] = readData;
+
+                if (readData) {
+                    key = "ilib.data." + jsonName + "_" + lang;
+                    orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                    parseData = JSON.parse(readData);
+                    mergeData = JSUtils.merge(orgData, parseData, true);
+                    outFile[lang][key] = mergeData;
+                }
 
                 if (script) {
-                    jsonPath = path.join(iliblocalePath, lang, script, jsonName + ".json");
+                    jsonPath = path.join(dataPath, lang, script, jsonName + ".json");
                     readData = readFile(jsonPath);
-                    if (readData) outFile[lang]["ilib.data." + jsonName + "_" + lang + "_" + script] = readData;
+                    if (readData) {
+                        key = "ilib.data." + jsonName + "_" + lang + "_" + script;
+                        orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                        parseData = JSON.parse(readData);
+                        mergeData = JSUtils.merge(orgData, parseData, true);
+                        outFile[lang][key] = mergeData;
+                    }
 
                     if (region) {
-                        jsonPath = path.join(iliblocalePath, lang, region, jsonName + ".json");
+                        jsonPath = path.join(dataPath, lang, region, jsonName + ".json");
                         readData = readFile(jsonPath);
-                        if (readData) outFile[lang]["ilib.data." + jsonName + "_" + lang + "_" + region] = readData;
 
-                        jsonPath = path.join(iliblocalePath, lang, script, region, jsonName + ".json");
-                        readData = readFile(jsonPath);
-                        if (readData) outFile[lang]["ilib.data." + jsonName + "_" + lang + "_" + script + "_" + region] = readData;
+                        if (readData) {
+                            key = "ilib.data." + jsonName + "_" + lang + "_" + region;
+                            orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                            parseData = JSON.parse(readData);
+                            mergeData = JSUtils.merge(orgData, parseData, true);
+                            outFile[lang][key] = mergeData;
+                        }
 
-                        jsonPath = path.join(iliblocalePath, "und", region, jsonName + ".json");
+                        jsonPath = path.join(dataPath, lang, script, region, jsonName + ".json");
                         readData = readFile(jsonPath);
-                        if (readData) outFile[lang]["ilib.data." + jsonName + "_und_" + region] = readData;
+                        if (readData) {
+                            key = "ilib.data." + jsonName + "_" + lang + "_" + script + "_" + region;
+                            orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                            parseData = JSON.parse(readData);
+                            mergeData = JSUtils.merge(orgData, parseData, true);
+                            outFile[lang][key] = mergeData;
+                        }
+
+                        jsonPath = path.join(dataPath, "und", region, jsonName + ".json");
+                        readData = readFile(jsonPath);
+                        if (readData) {
+                            key = "ilib.data." + jsonName + "_und_" + region;
+                            orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                            parseData = JSON.parse(readData);
+                            mergeData = JSUtils.merge(orgData, parseData, true);
+                            outFile[lang][key] = mergeData;
+                        }
                     }
                 } else if (region) {
-                    jsonPath = path.join(iliblocalePath, lang, region, jsonName + ".json");
+                    jsonPath = path.join(dataPath, lang, region, jsonName + ".json");
                     readData = readFile(jsonPath);
-                    if (readData) outFile[lang]["ilib.data." + jsonName + "_" + lang + "_" + region] = readData;
+                    if (readData) {
+                        key = "ilib.data." + jsonName + "_" + lang + "_" + region;
+                        orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                        parseData = JSON.parse(readData);
+                        mergeData = JSUtils.merge(orgData, parseData, true);
+                        outFile[lang][key] = mergeData;
+                    }
 
-                    jsonPath = path.join(iliblocalePath, "und", region, jsonName + ".json");
+                    jsonPath = path.join(dataPath, "und", region, jsonName + ".json");
                     readData = readFile(jsonPath);
-                    if (readData) outFile[lang]["ilib.data." + jsonName + "_und_" + region] = readData;
+                    if (readData) {
+                        key = "ilib.data." + jsonName + "_und_" + region;
+                        orgData = ((outFile[lang][key]) != undefined) ? outFile[lang][key] : {};
+                        parseData = JSON.parse(readData);
+                        mergeData = JSUtils.merge(orgData, parseData, true);
+                        outFile[lang][key] = mergeData;
+                    }
                 }
             } else {
                 console.log("The locale " + lo.getSpec() +  " is missing language code.");
@@ -311,14 +287,22 @@ function assembleLocale() {
         });
     });
 
+    return outFile;
+}
+
+
+function assembleLocale() {
+    let result = {};
+    result = assembleData(path.join(ilibPath, "js/data/locale"), result);
+
     if (customPath) {
-        outFile = assembleCustomLocale(outFile);
+        result = assembleData(customPath, result);
     }
 
-    for (let loc in outFile) {
+    for (let loc in result) {
         let contents = "";
-        for(let keys in outFile[loc]){
-            contents += keys + " = " + outFile[loc][keys] + "\n";
+        for(let keys in result[loc]){
+            contents += keys + " = " + JSON.stringify(result[loc][keys]) + "\n";
         }
         console.log("writing " + outDir + "/"+ loc + ".js file.");
         let resultFilePath = path.join(outDir, loc + ".js");


### PR DESCRIPTION
* Add the new `customLocalePath` option to provide a way of overriding user-defined locale data
 note) verified the output by running testcase for webOS custom data (https://github.com/iLib-js/flutter_ilib/tree/customTest/test/custom)